### PR TITLE
[Enhancement] Doris broker support aliyun-oss #13665

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExportStmt.java
@@ -240,9 +240,10 @@ public class ExportStmt extends StatementBase {
                     && !schema.equalsIgnoreCase("afs")
                     && !schema.equalsIgnoreCase("hdfs")
                     && !schema.equalsIgnoreCase("ofs")
-                    && !schema.equalsIgnoreCase("obs"))) {
+                    && !schema.equalsIgnoreCase("obs")
+                    && !schema.equalsIgnoreCase("oss"))) {
                 throw new AnalysisException("Invalid export path. please use valid 'HDFS://', 'AFS://' , 'BOS://', "
-                    + "or 'ofs://' or 'obs://' path.");
+                    + "'oss://'," + "or 'ofs://' or 'obs://' path.");
             }
         } else if (type == StorageBackend.StorageType.S3) {
             if (schema == null || !schema.equalsIgnoreCase("s3")) {

--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -69,7 +69,7 @@ under the License.
         <maven.compiler.target>1.8</maven.compiler.target>
         <log4j2.version>2.18.0</log4j2.version>
         <project.scm.id>github</project.scm.id>
-        <hadoop.version>2.8.3</hadoop.version>
+        <hadoop.version>2.9.1</hadoop.version>
     </properties>
     <profiles>
         <!-- for custom internal repository -->
@@ -284,6 +284,12 @@ under the License.
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-huaweicloud</artifactId>
+            <version>2.8.3</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aliyun -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-aliyun</artifactId>
             <version>${hadoop.version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13665

## Problem summary

Describe your changes.
1 Upgrade fs_broker module hadoop2.8.3->hadoop2.9.1
2 Broker support oss://
3 Version of jar file  hadoop-huaweicloud used by broker  is set to 2.8.3

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [x] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments
1.  Test case :doris broker升级hadoop2.9.1后访问obs

LOAD LABEL demo.load_oss_label_hw (
  DATA INFILE(
    "obs://weinan-test1.obs.cn-east-3.myhuaweicloud.com/data2.csv"
  ) INTO TABLE example_tbl_hw COLUMNS TERMINATED BY ","
) WITH BROKER "broker_za" (
  "fs.obs.access.key" = "xxxxx",
  "fs.obs.secret.key" = "xxxxxxx",
  "fs.obs.endpoint" = "https://obs.cn-east-3.myhuaweicloud.com"
)
测试结果符合预期，兼容2.8.3版本的hadoop
执行结果：
![image](https://user-images.githubusercontent.com/21140069/200253817-9bfc4d13-ab42-4b77-8972-9f60e4584060.png)

后台记录：
![image](https://user-images.githubusercontent.com/21140069/200253911-77e7bde6-3988-4d7d-a296-6e6b12e7f03a.png)

结果检查：
![image](https://user-images.githubusercontent.com/21140069/200253935-b05ccd65-964f-49cc-8a94-3e394f208db4.png)




2. Test cast :Doris broker支持OSS协议测试

1 Load with Broker
用例：先导入6条数据，再通过OSS导入7条数据（在原始数据基础上增加了一条）
原始数据：
10000,2017-10-01,北京,20,0,2017-10-01 06:00:00,20,10,10
10000,2017-10-01,北京,20,0,2017-10-01 07:00:00,15,2,2
10001,2017-10-01,北京,30,1,2017-10-01 17:05:45,2,22,22
10002,2017-10-02,上海,20,1,2017-10-02 12:59:12,200,5,5
10003,2017-10-02,广州,32,0,2017-10-02 11:20:00,30,11,11
10004,2017-10-01,深圳,35,0,2017-10-01 10:00:15,100,3,3
10004,2017-10-03,深圳,35,0,2017-10-03 10:20:22,11,6,6

OSS上的数据data.csv
10000,2017-10-01,北京,20,0,2017-10-01 06:00:00,20,10,10
10000,2017-10-01,北京,20,0,2017-10-01 07:00:00,15,2,2
10001,2017-10-01,北京,30,1,2017-10-01 17:05:45,2,22,22
10002,2017-10-02,上海,20,1,2017-10-02 12:59:12,200,5,5
10003,2017-10-02,广州,32,0,2017-10-02 11:20:00,30,11,11
10004,2017-10-01,深圳,35,0,2017-10-01 10:00:15,100,3,3
10004,2017-10-03,深圳,35,0,2017-10-03 10:20:22,11,6,6
10005,2017-10-03,深圳,35,0,2017-10-03 10:20:22,11,6,6


导入语句
    LOAD LABEL demo.load_oss_label_1
    (
        DATA INFILE("oss://otsosstest/doris/data.csv")
        INTO TABLE example_tbl
        COLUMNS TERMINATED BY ","
    )
    WITH BROKER "broker_za"
    (
        "fs.oss.endpoint" = "https://xxxxx",
        "fs.oss.accessKeyId" = "xxxxx",
        "fs.oss.accessKeySecret"="xxxxx"
)
执行结果：符合预期
1.前端执行：
![image](https://user-images.githubusercontent.com/21140069/200253220-7ccb292d-cce5-448d-9fc3-fb77a5744413.png)

2.Load任务
![image](https://user-images.githubusercontent.com/21140069/200253286-ec292fdb-fe08-43b4-87ea-1cdb45dbc71c.png)

3.数据检查
![image](https://user-images.githubusercontent.com/21140069/200253312-90253f3c-81fc-4601-894b-330742cd7f8d.png)




2 Export with Borker
用例：将刚才的7条数据导入到OSS上
EXPORT TABLE demo.example_tbl
TO "oss://otsosstest/doris/export_broker/01/"
PROPERTIES
(
    "label" = "export_from_doris_18",
    "column_separator"=",",
    "timeout" = "3600"
)
WITH BROKER "broker_za"
(
        "fs.oss.endpoint" = "https://oss-cn-hangzhou.aliyuncs.com",
        "fs.oss.accessKeyId" = "xxxxx",
        "fs.oss.accessKeySecret"="xxxxx"
);
测试结果符合预期
执行结果
![image](https://user-images.githubusercontent.com/21140069/200253380-afa72c1d-7993-4173-a568-6f4b8455ec83.png)
后台执行结果
![image](https://user-images.githubusercontent.com/21140069/200253393-fdd1a744-5476-42bb-9ba9-8fd18595e984.png)
oss上导出的文件：
![image](https://user-images.githubusercontent.com/21140069/200253407-919a5ee1-c325-4b9b-a67a-a2af7e089c53.png)
oss上导出的文件内容：
![image](https://user-images.githubusercontent.com/21140069/200253428-983f09e4-81e7-4e63-bcbd-cbb0b91109d8.png)


3 Outfile export with Broker
select * from  demo.example_tbl
into outfile "oss://streamoss-1/doris/newbroker/01"
FORMAT AS CSV
PROPERTIES
(

    "broker.name" = "broker_za",
    "broker.fs.oss.endpoint" = "https://oss-cn-hangzhou.aliyuncs.com",
    "broker.fs.oss.accessKeyId" = "xxxxxx",
    "broker.fs.oss.accessKeySecret"="xxxxxxx",
    "column_separator" = ",",
    "line_delimiter" = "\n",


检查结果：符合预期
执行结果
![image](https://user-images.githubusercontent.com/21140069/200253675-32d7bd30-b3ad-4a01-bc0f-f3130826617f.png)
oss上导出的文件：
![image](https://user-images.githubusercontent.com/21140069/200253626-e41fa9ce-8f63-461a-b291-79a180b0e98e.png)
oss上导出的文件内容
![image](https://user-images.githubusercontent.com/21140069/200253654-ef30b5fc-0f2b-4f15-9b68-9722caf921b0.png)




If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

